### PR TITLE
Fix GitTrendAPI Tests

### DIFF
--- a/GitTrendTests/GitTrendAPITests.swift
+++ b/GitTrendTests/GitTrendAPITests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import GitTrend
 
 class GitTrendAPITests: XCTestCase {
-    var expectedURL = URL(string: "https://ghapi.huchen.dev/repositories?language=swift&since=weekly")!
+    var expectedURL = URL(string: "https://ghapi.huchen.dev/repositories?language=swift&since=weekly&spoken_language_code=en")!
     var returnedRepos: [Repo] = []
     var testBundle: Bundle { Bundle(for: Self.self) }
 


### PR DESCRIPTION
URL hadn't been updated to reflect the
spoken language code parameter added
for English only results.